### PR TITLE
Resolved the bug that mighty cannot treat query strings correctly via Rev. Proxy

### DIFF
--- a/Network/Wai/Application/Classic/RevProxy.hs
+++ b/Network/Wai/Application/Classic/RevProxy.hs
@@ -26,7 +26,11 @@ toHTTPRequest req route len = H.def {
   , H.secure = isSecure req
   , H.requestHeaders = addForwardedFor req $ requestHeaders req
   , H.path = pathByteString path'
-  , H.queryString = BS.drop 1 $ rawQueryString req
+  , H.queryString =
+      let q = rawQueryString req
+      in if "?" `BS.isPrefixOf` q
+         then BS.drop 1 q
+         else q
   , H.requestBody = getBody req len
   , H.method = requestMethod req
   , H.proxy = Nothing


### PR DESCRIPTION
Because WAI's `rawQueryString` has '?' as its prefix and http-conduit not, mighttpd2 couldn't treat query strings via Rev. Proxy collectly.

I resolved this by stripping prefix '?'.
