### PR TITLE
Avoid multiple "Transfer-Encoding: chunked" header.

### DIFF
--- a/Network/Wai/Application/Classic/Field.hs
+++ b/Network/Wai/Application/Classic/Field.hs
@@ -10,6 +10,7 @@ import Data.ByteString.Char8 as BS (pack)
 import qualified Data.Map as Map (toList)
 import Data.Maybe
 import Data.StaticHash (StaticHash)
+import Data.List (delete)
 import qualified Data.StaticHash as SH
 import qualified Data.Text as T
 import Network.HTTP.Date
@@ -68,6 +69,9 @@ addVia cspec req hdr = (hVia, val) : hdr
       , softwareName cspec
       , ")"
       ]
+
+deleteTransferEncoding :: ResponseHeaders -> ResponseHeaders
+deleteTransferEncoding hdr = delete ("Transfer-Encoding", "chunked") hdr
 
 addForwardedFor :: Request -> ResponseHeaders -> ResponseHeaders
 addForwardedFor req hdr = (hXForwardedFor, addr) : hdr

--- a/Network/Wai/Application/Classic/RevProxy.hs
+++ b/Network/Wai/Application/Classic/RevProxy.hs
@@ -81,7 +81,7 @@ revProxyApp' cspec spec route req = do
     ResponseSource status hdr <$> toSource (lookup hContentType hdr) rdownbody
   where
     mgr = revProxyManager spec
-    fixHeader = addVia cspec req . filter p
+    fixHeader = deleteTransferEncoding . addVia cspec req . filter p
     p (k,_)
       | k == hContentEncoding = False
       | k == hContentLength   = False


### PR DESCRIPTION
Multiple Transfer-Encoding is accepted on HTTP/1.1.
But, an error has occured on part of devices.
(I encounter the error on iPhone4S SoftBank 3G)

Additionally, response body that is returned by
Network.HTTP.Conduit is already decoded.
So, "Transfer-Encoding: chunked" header should be deleted.
