### PR TITLE
RevProxy: add X-Forwarded-Proto

### DIFF
--- a/Network/Wai/Application/Classic/Field.hs
+++ b/Network/Wai/Application/Classic/Field.hs
@@ -28,10 +28,10 @@ languages = maybe [] parseLang . lookup hAcceptLanguage
 ----------------------------------------------------------------
 
 textPlainHeader :: ResponseHeaders
-textPlainHeader = [(hContentType,"text/plain")]
+textPlainHeader = [(hContentType, "text/plain")]
 
 textHtmlHeader :: ResponseHeaders
-textHtmlHeader = [(hContentType,"text/html")]
+textHtmlHeader = [(hContentType, "text/html")]
 
 locationHeader :: ByteString -> ResponseHeaders
 locationHeader url = [(hLocation, url)]
@@ -58,13 +58,18 @@ addForwardedFor req hdr = (hXForwardedFor, addr) : hdr
   where
     addr = B8.pack . showSockAddr . remoteHost $ req
 
+addForwardedProto :: Request -> ResponseHeaders -> ResponseHeaders
+addForwardedProto req hdr = (hXForwardedProto, proto) : hdr
+  where
+    proto = if isSecure req then "https" else "http"
+
 newHeader :: Bool -> ByteString -> ResponseHeaders
 newHeader ishtml file
   | ishtml    =  textHtmlHeader
   | otherwise = [(hContentType, mimeType file)]
 
 mimeType :: ByteString -> MimeType
-mimeType file =fromMaybe defaultMimeType . foldr1 mplus . map lok $ targets
+mimeType file = fromMaybe defaultMimeType . foldr1 mplus . map lok $ targets
   where
     targets = extensions file
     lok x = SH.lookup x defaultMimeTypes'

--- a/Network/Wai/Application/Classic/Header.hs
+++ b/Network/Wai/Application/Classic/Header.hs
@@ -21,6 +21,10 @@ hStatus = "status"
 hXForwardedFor :: HeaderName
 hXForwardedFor = "x-forwarded-for"
 
+-- | Lookup key for X-Forwarded-Proto.
+hXForwardedProto :: HeaderName
+hXForwardedProto = "x-forwarded-proto"
+
 -- | Look-up key for Via.
 hVia :: HeaderName
 hVia = "via"

--- a/Network/Wai/Application/Classic/RevProxy.hs
+++ b/Network/Wai/Application/Classic/RevProxy.hs
@@ -58,7 +58,7 @@ reqToHReq req route = def {
     H.host           = revProxyDomain route
   , H.port           = revProxyPort route
   , H.secure         = False -- FIXME: upstream is HTTP only
-  , H.requestHeaders = addForwardedFor req $ filter headerToBeRelay hdr
+  , H.requestHeaders = addForwardedHeaders $ filter headerToBeRelay hdr
   , H.path           = pathByteString path'
   , H.queryString    = dropQuestion query
   , H.requestBody    = bodyToHBody len body
@@ -81,6 +81,9 @@ reqToHReq req route = def {
     dropQuestion q = case BS.uncons q of
         Just (63, q') -> q' -- '?' is 63
         _             -> q
+    addForwardedHeaders
+        = addForwardedFor req
+        . addForwardedProto req
 
 bodyToHBody :: RequestBodyLength -> IO ByteString -> H.RequestBody
 bodyToHBody ChunkedBody src       = H.RequestBodyStreamChunked ($ src)


### PR DESCRIPTION
Some applications behind the reverse proxy may want to know if https is used between the client and the proxy. For example to render `https://` urls instead of `http://`.
