### PR TITLE
Fix MIME detection for files with no extension.

### DIFF
--- a/Network/Wai/Application/Classic/Field.hs
+++ b/Network/Wai/Application/Classic/Field.hs
@@ -64,7 +64,7 @@ newHeader ishtml file
   | otherwise = [(hContentType, mimeType file)]
 
 mimeType :: ByteString -> MimeType
-mimeType file =fromMaybe defaultMimeType . foldr1 mplus . map lok $ targets
+mimeType file = fromMaybe defaultMimeType . foldr mplus Nothing . map lok $ targets
   where
     targets = extensions file
     lok x = SH.lookup x defaultMimeTypes'

--- a/test/ClassicSpec.hs
+++ b/test/ClassicSpec.hs
@@ -29,6 +29,11 @@ spec = do
             bdy <- rspBody <$> sendGET url
             ans <- readFileAscii "test/html/index.html"
             bdy `shouldBe` ans
+        it "works with files that lack a file extension" $ do
+            let url = "http://127.0.0.1:2345/no_extension"
+            bdy <- rspBody <$> sendGET url
+            ans <- readFileAscii "test/html/no_extension"
+            bdy `shouldBe` ans
         it "returns 400 if not exist" $ do
             let url = "http://127.0.0.1:2345/dummy"
             sc <- rspCode <$> sendGET url

--- a/test/html/no_extension
+++ b/test/html/no_extension
@@ -1,0 +1,1 @@
+This is a file without an extension! Hi!


### PR DESCRIPTION
Previously, the `mimeType` function would crash on files with no extension due to the use of `foldr1`.