### PR TITLE
Remove deprecated dependency on attoparsec-conduit

### DIFF
--- a/wai-app-file-cgi.cabal
+++ b/wai-app-file-cgi.cabal
@@ -41,7 +41,6 @@ Library
   Build-Depends:        base >= 4.9 && < 5
                       , array
                       , attoparsec >= 0.10.0.0
-                      , attoparsec-conduit
                       , bytestring
                       , case-insensitive
                       , conduit >= 1.1


### PR DESCRIPTION
It's now an empty deprecated shim package.

Builds fine and all tests pass here.