### PR TITLE
Update source repository to use https

### DIFF
--- a/wai-app-file-cgi.cabal
+++ b/wai-app-file-cgi.cabal
@@ -104,4 +104,4 @@ Test-Suite spec
 
 Source-Repository head
   Type:                 git
-  Location:             git://github.com/kazu-yamamoto/wai-app-file-cgi
+  Location:             https://github.com/kazu-yamamoto/wai-app-file-cgi


### PR DESCRIPTION
`git://` is no longer supported.