### PR TITLE
Update source repository to use https

### DIFF
--- a/wai-app-file-cgi.cabal
+++ b/wai-app-file-cgi.cabal
@@ -25,7 +25,7 @@ extra-source-files:
 
 source-repository head
     type:     git
-    location: git://github.com/kazu-yamamoto/wai-app-file-cgi
+    location: https://github.com/kazu-yamamoto/wai-app-file-cgi
 
 library
     exposed-modules:  Network.Wai.Application.Classic


### PR DESCRIPTION
`git://` is no longer supported.

Reopened from #18