### PR TITLE
Support FileRoutes mapping files to files

### DIFF
--- a/Network/Wai/Application/Classic/FileInfo.hs
+++ b/Network/Wai/Application/Classic/FileInfo.hs
@@ -6,6 +6,34 @@ import Network.Wai.Application.Classic.Types
 
 ----------------------------------------------------------------
 
+{- |
+>>> :set -XOverloadedStrings
+>>> import Network.Wai (defaultRequest)
+>>> import Network.Wai.Internal (Request (..))
+>>> mkReq p = defaultRequest { rawPathInfo = p }
+>>> pathinfoToFilePath (mkReq "/") (FileRoute "/" "/srv/http")
+"/srv/http/"
+>>> pathinfoToFilePath (mkReq "/") (FileRoute "/" "/srv/http/")
+"/srv/http/"
+>>> pathinfoToFilePath (mkReq "/hello") (FileRoute "/" "/srv/http/")
+"/srv/http/hello"
+>>> pathinfoToFilePath (mkReq "/hello/") (FileRoute "/" "/srv/http/")
+"/srv/http/hello/"
+>>> pathinfoToFilePath (mkReq "/about/wai.html") (FileRoute "/" "/srv/http/")
+"/srv/http/about/wai.html"
+>>> pathinfoToFilePath (mkReq "/hello/") (FileRoute "/sub/dir/" "/var/root/")
+"/var/root/"
+>>> pathinfoToFilePath (mkReq "/sub/dir/") (FileRoute "/sub/dir/" "/var/root/")
+"/var/root/"
+>>> pathinfoToFilePath (mkReq "/sub/dir/test.html") (FileRoute "/sub/dir/" "/var/root/")
+"/var/root/test.html"
+>>> pathinfoToFilePath (mkReq "/exact/match") (FileRoute "/exact/match" "/tmp/dst")
+"/tmp/dst/"
+>>> pathinfoToFilePath (mkReq "/exact/match/") (FileRoute "/exact/match" "/tmp/dst")
+"/tmp/dst/"
+>>> pathinfoToFilePath (mkReq "/exact/match/more.html") (FileRoute "/exact/match" "/tmp/dst")
+"/tmp/dst/more.html"
+-}
 pathinfoToFilePath :: Request -> FileRoute -> Path
 pathinfoToFilePath req filei = path'
   where

--- a/Network/Wai/Application/Classic/FileInfo.hs
+++ b/Network/Wai/Application/Classic/FileInfo.hs
@@ -7,11 +7,15 @@ import Network.Wai.Application.Classic.Types
 
 ----------------------------------------------------------------
 
-{- |
+{- $setup
 >>> :set -XOverloadedStrings
 >>> import Network.Wai (defaultRequest)
 >>> import Network.Wai.Internal (Request (..))
 >>> mkReq p = defaultRequest { rawPathInfo = p }
+>>> import Network.Wai.Application.Classic.Def (defaultFileAppSpec)
+-}
+
+{- |
 >>> pathinfoToFilePath (mkReq "/") (FileRoute "/" "/srv/http")
 "/srv/http"
 >>> pathinfoToFilePath (mkReq "/") (FileRoute "/" "/srv/http/")
@@ -45,6 +49,17 @@ pathinfoToFilePath req filei
     dst = fileDst filei
     path' = path <\> src
 
+{- |
+
+It matters to 'pathinfoToFilePath' whether the 'FileRoute' has trailing slashes
+which also influences 'addIndex':
+
+>>> addIndex defaultFileAppSpec (pathinfoToFilePath (mkReq "/exact/match.html") (FileRoute "/exact/match.html" "/some/file.html"))
+"/some/file.html"
+>>> addIndex defaultFileAppSpec (pathinfoToFilePath (mkReq "/some/dir") (FileRoute "/some/dir/" "/target/dir/"))
+"/target/dir/index.html"
+
+-}
 addIndex :: FileAppSpec -> Path -> Path
 addIndex spec path
   | hasTrailingPathSeparator path = path </> indexFile spec

--- a/Network/Wai/Application/Classic/FileInfo.hs
+++ b/Network/Wai/Application/Classic/FileInfo.hs
@@ -1,5 +1,6 @@
 module Network.Wai.Application.Classic.FileInfo where
 
+import qualified Data.ByteString as BS
 import Network.Wai
 import Network.Wai.Application.Classic.Path
 import Network.Wai.Application.Classic.Types
@@ -12,7 +13,7 @@ import Network.Wai.Application.Classic.Types
 >>> import Network.Wai.Internal (Request (..))
 >>> mkReq p = defaultRequest { rawPathInfo = p }
 >>> pathinfoToFilePath (mkReq "/") (FileRoute "/" "/srv/http")
-"/srv/http/"
+"/srv/http"
 >>> pathinfoToFilePath (mkReq "/") (FileRoute "/" "/srv/http/")
 "/srv/http/"
 >>> pathinfoToFilePath (mkReq "/hello") (FileRoute "/" "/srv/http/")
@@ -28,19 +29,21 @@ import Network.Wai.Application.Classic.Types
 >>> pathinfoToFilePath (mkReq "/sub/dir/test.html") (FileRoute "/sub/dir/" "/var/root/")
 "/var/root/test.html"
 >>> pathinfoToFilePath (mkReq "/exact/match") (FileRoute "/exact/match" "/tmp/dst")
-"/tmp/dst/"
+"/tmp/dst"
 >>> pathinfoToFilePath (mkReq "/exact/match/") (FileRoute "/exact/match" "/tmp/dst")
 "/tmp/dst/"
 >>> pathinfoToFilePath (mkReq "/exact/match/more.html") (FileRoute "/exact/match" "/tmp/dst")
 "/tmp/dst/more.html"
 -}
 pathinfoToFilePath :: Request -> FileRoute -> Path
-pathinfoToFilePath req filei = path'
+pathinfoToFilePath req filei
+  | BS.null path' = dst
+  | otherwise     = dst </> path'
   where
     path = rawPathInfo req
     src = fileSrc filei
     dst = fileDst filei
-    path' = dst </> (path <\> src) -- fixme
+    path' = path <\> src
 
 addIndex :: FileAppSpec -> Path -> Path
 addIndex spec path

--- a/Network/Wai/Application/Classic/Types.hs
+++ b/Network/Wai/Application/Classic/Types.hs
@@ -34,10 +34,33 @@ data FileAppSpec = FileAppSpec {
   , isHTML :: Path -> Bool
   }
 
+-- | 'FileRoute' describes the relationship between Paths requested via HTTP
+--   and paths to serve on disk. Specifically, it maps a /single/ path
+--   prefix to a destination path, so the 'FileRoute' needs to be applicable
+--   to the current request,
+--   e.g. @FileRoute "\/static\/" "\/var\/www\/static\/"@ will yield a 404 if
+--   @"/page.html"@ is requested.
+--   In the simplest case @FileRoute "\/" "\/var\/www\/"@ routes everything
+--   to a single destination path.
+--
+--   When resolving routes, no filesystem reads are performed, so path
+--   type needs to be inferred from the path.
+--
+--   * If 'fileSrc' and 'fileDst' have a trailing slash, source and
+--     destination are assumed to be directories (this e.g. enables
+--     fallback to index files).
+--
+--   * If 'fileSrc' and 'fileDst' lack a trailing slash, they are
+--     assumed to be files. This is supported since 3.2.0.
+--
+--   If the path type inferrable from 'FileRoute' does not match
+--   the type of the destination path on disk, routes will not
+--   resolve correctly. If the inferrable type doesn't match
+--   between 'fileSrc' and 'fileDst', routing may also misbehave.
 data FileRoute = FileRoute {
-    -- | Path prefix to be matched to 'rawPathInfo'.
+    -- | Path (prefix) to be matched to 'rawPathInfo'.
     fileSrc :: Path
-    -- | Path prefix to an actual file system.
+    -- | Path to the target directory or file.
   , fileDst :: Path
   } deriving (Eq,Show)
 

--- a/test/ClassicSpec.hs
+++ b/test/ClassicSpec.hs
@@ -85,6 +85,11 @@ spec = do
                 Just lm = lookupHeader HdrLocation hdr
             sc `shouldBe` (3,0,1)
             lm `shouldBe` "//127.0.0.1:2345/redirect/"
+        it "returns index.html for /exact-route.html matching exactRoute" $ do
+            let url = "http://127.0.0.1:2345/exact-route.html"
+            bdy <- rspBody <$> sendGET url
+            ans <- readFileAscii "test/html/index.html"
+            bdy `shouldBe` ans
 
 ----------------------------------------------------------------
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -30,14 +30,20 @@ testServer = do
 
 testApp :: FilePath -> Application
 testApp dir req
-    | cgi       = cgiApp  appSpec defaultCgiAppSpec  cgiRoute  req
-    | otherwise = fileApp appSpec defaultFileAppSpec fileRoute req
+    | cgi       = cgiApp  appSpec defaultCgiAppSpec  cgiRoute   req
+    | exact     = fileApp appSpec defaultFileAppSpec exactRoute req
+    | otherwise = fileApp appSpec defaultFileAppSpec fileRoute  req
   where
     cgi = "/cgi-bin/" `BS.isPrefixOf` rawPathInfo req
+    exact = "/exact-route.html" `BS.isPrefixOf` rawPathInfo req
     appSpec = defaultClassicAppSpec { softwareName = "ClassicTester" }
     cgiRoute = CgiRoute {
         cgiSrc = "/cgi-bin/"
       , cgiDst = fromString (dir </> "test/cgi-bin/")
+      }
+    exactRoute = FileRoute {
+        fileSrc = "/exact-route.html"
+      , fileDst = fromString (dir </> "test/html/index.html")
       }
     fileRoute = FileRoute {
         fileSrc = "/"

--- a/wai-app-file-cgi.cabal
+++ b/wai-app-file-cgi.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               wai-app-file-cgi
-version:            3.1.12
+version:            3.2.0
 license:            BSD3
 license-file:       LICENSE
 maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>


### PR DESCRIPTION
When the rawPathInfo matches the fileSrc exactly, don't add a trailing slash to it, but just return dst. This way, it becomes possible to create routes that map a specific file to another.

Resolves #22.